### PR TITLE
Safer start

### DIFF
--- a/neware_api/neware.py
+++ b/neware_api/neware.py
@@ -197,7 +197,8 @@ class NewareAPI:
         }
         if blocked_pipelines:
             msg = (
-                "Can only start jobs if pipeline state is 'finish', 'stop', or 'protect'. "
+                 "Can only start jobs if pipeline state is "
+                 f"{', '.join(repr(state) for state in allowed_states)}. "
                 "The following pipelines are in blocked states: "
                 f"{blocked_pipelines}"
             )


### PR DESCRIPTION
If trying to start a job on a currently running pipeline, it would fail with an error. However, when starting a job on a paused pipeline, the CLI would **fail silently**.

Now, explicitly check the pipeline is available to start before job submission.

Gets the current state of pipelines, if any are not `finish` `stop` or `protect`, refuse to start any jobs.

Tested and working on the CLI on all states: `working`, `pause`, `finish`, `stop`, `protect`.