### PR TITLE
CLI clear-flag command

### DIFF
--- a/aurora_neware/cli/main.py
+++ b/aurora_neware/cli/main.py
@@ -203,7 +203,7 @@ def stop(pipeline_id: str) -> None:
 
 
 @app.command()
-def clearflag(pipeline_ids: Annotated[list[str], typer.Argument()], indent: IndentOption = None) -> None:
+def clear_flag(pipeline_ids: Annotated[list[str], typer.Argument()], indent: IndentOption = None) -> None:
     """Clear flag on selected channel(s).
 
     Example usage:
@@ -217,6 +217,10 @@ def clearflag(pipeline_ids: Annotated[list[str], typer.Argument()], indent: Inde
     """
     with NewareAPI() as nw:
         typer.echo(json.dumps(nw.clearflag(pipeline_ids), indent=indent))
+
+
+# For backwards compatibility
+app.command("clearflag", hidden=True)(clear_flag)
 
 
 @app.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,8 +135,16 @@ def test_stop(mock_bts) -> None:
     assert "could not stop job" in result.stderr
 
 
+def test_clear_flag(mock_bts) -> None:
+    """Test clear-flag CLI command."""
+    result = runner.invoke(app, ["clear-flag", "21-1-1"])
+    assert result.exit_code == 0
+    output = json.loads(result.stdout)
+    assert output == [{"ip": "127.0.0.1", "devtype": 27, "devid": 21, "subdevid": 1, "chlid": 1, "clearflag": "false"}]
+
+
 def test_clearflag(mock_bts) -> None:
-    """Test clearflag CLI command."""
+    """Test legacy clearflag CLI command."""
     result = runner.invoke(app, ["clearflag", "21-1-1"])
     assert result.exit_code == 0
     output = json.loads(result.stdout)


### PR DESCRIPTION
With dash for consistency with other commands, keeps `clearflag` for backwards compatibility